### PR TITLE
Fix emote-related bugs

### DIFF
--- a/EmotesMod/Modules/Components/EmoteBehaviour.cs
+++ b/EmotesMod/Modules/Components/EmoteBehaviour.cs
@@ -24,7 +24,7 @@ namespace EmotesMod.Modules.Components
 
         public IEnumerator CoHandleIdleEmote(bool loop)
         {
-            HudManagerPatches.EmoteCanvas.transform.GetChild(1).gameObject.SetActive(true);
+            if (pc.AmOwner) HudManagerPatches.EmoteCanvas.transform.GetChild(1).gameObject.SetActive(true);
             pc.cosmetics.gameObject.SetActive(false);
             if (loop)
             {
@@ -40,7 +40,7 @@ namespace EmotesMod.Modules.Components
             pc.cosmetics.gameObject.SetActive(true);
             currentEmote = null!;
             pc.MyPhysics.Animations.PlayIdleAnimation();
-            HudManagerPatches.EmoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
+            if (pc.AmOwner) HudManagerPatches.EmoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
             yield break;
         }
 

--- a/EmotesMod/Modules/Components/EmoteBehaviour.cs
+++ b/EmotesMod/Modules/Components/EmoteBehaviour.cs
@@ -29,7 +29,7 @@ namespace EmotesMod.Modules.Components
             if (loop)
             {
                 Vector2 originalPos = pc.GetTruePosition();
-                while (originalPos == pc.GetTruePosition())
+                while (currentEmote && originalPos == pc.GetTruePosition())
                 {
                     pc.MyPhysics.Animations.Animator.Play(currentEmote.anim.Value);
                     yield return new WaitForSeconds(currentEmote.anim.Value.length);

--- a/EmotesMod/Patches/HudManagerPatches.cs
+++ b/EmotesMod/Patches/HudManagerPatches.cs
@@ -1,9 +1,7 @@
 using System;
 using EmotesMod.Modules.Components;
 using HarmonyLib;
-using Rewired;
 using UnityEngine;
-using UnityEngine.Events;
 using UnityEngine.UI;
 using Object = UnityEngine.Object;
 
@@ -12,56 +10,67 @@ namespace EmotesMod.Patches;
 [HarmonyPatch]
 public class HudManagerPatches
 {
-    public static GameObject EmoteCanvas;
-    
+    private static GameObject _emoteCanvas;
+
+    public static GameObject EmoteCanvas
+    {
+        get
+        {
+            if (_emoteCanvas.IsDestroyedOrNull()) LazyInstantiateHud();
+
+            return _emoteCanvas;
+        }
+    }
+
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.Update))]
     [HarmonyPostfix]
     public static void HudManager_Update_Postfix(HudManager __instance)
     {
-        if (EmoteCanvas == null) return;
-
-        if (/*ReInput.players.GetPlayer(0).GetButtonDown(InputPatches.OpenEmoteWheelBind.id)*/ Input.GetKeyDown(KeyCode.E) && Input.GetKey(KeyCode.LeftControl) && PlayerControl.LocalPlayer && !PlayerControl.LocalPlayer.Data.IsDead)
+        if ( /*ReInput.players.GetPlayer(0).GetButtonDown(InputPatches.OpenEmoteWheelBind.id)*/
+            Input.GetKeyDown(KeyCode.E) && Input.GetKey(KeyCode.LeftControl) && PlayerControl.LocalPlayer &&
+            !PlayerControl.LocalPlayer.Data.IsDead)
         {
             var wheel = EmoteCanvas.transform.GetChild(0).gameObject;
             wheel.SetActive(!wheel.activeSelf);
         }
 
-        if (/*ReInput.players.GetPlayer(0).GetButtonDown(InputPatches.StopEmotingBind.id)*/ Input.GetKeyDown(KeyCode.X)&& PlayerControl.LocalPlayer.GetComponent<EmoteBehaviour>().currentEmote)
-        {
+        if ( /*ReInput.players.GetPlayer(0).GetButtonDown(InputPatches.StopEmotingBind.id)*/
+            Input.GetKeyDown(KeyCode.X) && PlayerControl.LocalPlayer.GetComponent<EmoteBehaviour>().currentEmote)
             PlayerControl.LocalPlayer.RpcStopEmote();
-        }
     }
-    
+
     [HarmonyPatch(typeof(HudManager), nameof(HudManager.Start))]
     [HarmonyPostfix]
     public static void HudManager_Start_Postfix(HudManager __instance)
     {
-        EmoteCanvas = Object.Instantiate(Assets.EmoteCanvas);
-        EmoteCanvas.transform.GetChild(0).gameObject.SetActive(false);
-        EmoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
-        EmoteCanvas.transform.GetChild(1).GetChild(1).GetComponent<Button>().onClick.AddListener(new Action(() =>
-        {
-            PlayerControl.LocalPlayer.RpcStopEmote();
-            EmoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
-        }));
-
         if (OperatingSystem.IsAndroid())
-        {
             CreateButtonAndroid();
-        }
         else
-        {
-            __instance.Chat.AddChatWarning("<size=150%>Thanks for downloading Emotes Mod!</size>\nTo open the emote wheel, press Control + E!");
-        }
+            __instance.Chat.AddChatWarning(
+                "<size=150%>Thanks for downloading Emotes Mod!</size>\nTo open the emote wheel, press Control + E!");
     }
 
-    public static void CreateButtonAndroid()
+    private static void LazyInstantiateHud()
     {
-        var button = UnityEngine.Object
+        if (!_emoteCanvas.IsDestroyedOrNull()) return;
+
+        _emoteCanvas = Object.Instantiate(Assets.EmoteCanvas);
+        _emoteCanvas.transform.GetChild(0).gameObject.SetActive(false);
+        _emoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
+        _emoteCanvas.transform.GetChild(1).GetChild(1).GetComponent<Button>().onClick.AddListener(new Action(() =>
+        {
+            PlayerControl.LocalPlayer.RpcStopEmote();
+            _emoteCanvas.transform.GetChild(1).gameObject.SetActive(false);
+        }));
+    }
+
+    private static void CreateButtonAndroid()
+    {
+        var button = Object
             .Instantiate(HudManager.Instance.SettingsButton, HudManager.Instance.SettingsButton.transform.parent)
             .GetComponent<PassiveButton>();
         button.gameObject.name = "EmoteButton";
-        button.OnClick = new();
+        button.OnClick = new Button.ButtonClickedEvent();
         button.OnClick.AddListener(new Action(() =>
         {
             var wheel = EmoteCanvas.transform.GetChild(0).gameObject;
@@ -69,6 +78,6 @@ public class HudManagerPatches
         }));
         button.activeSprites.GetComponent<SpriteRenderer>().sprite = Assets.EmoteButtonHover;
         button.inactiveSprites.GetComponent<SpriteRenderer>().sprite = Assets.EmoteButton;
-        button.GetComponent<AspectPosition>().DistanceFromEdge = new(4.75f, 0.505f, -400f);
+        button.GetComponent<AspectPosition>().DistanceFromEdge = new Vector3(4.75f, 0.505f, -400f);
     }
 }

--- a/EmotesMod/Patches/PlayerControlPatches.cs
+++ b/EmotesMod/Patches/PlayerControlPatches.cs
@@ -1,8 +1,5 @@
-using System.Linq;
 using EmotesMod.Modules.Components;
 using HarmonyLib;
-using Rewired;
-using UnityEngine;
 
 namespace EmotesMod.Patches;
 
@@ -16,7 +13,7 @@ public class PlayerControlPatches
         __instance.gameObject.AddComponent<EmoteBehaviour>().pc = __instance;
         __instance.MyPhysics.Animations.glowAnimator.gameObject.SetActive(false);
     }
-    
+
     [HarmonyPatch(typeof(PlayerPhysics), nameof(PlayerPhysics.HandleAnimation))]
     [HarmonyPrefix]
     public static bool PlayerPhysics_Awake_Prefix(PlayerPhysics __instance)
@@ -31,7 +28,7 @@ public class PlayerControlPatches
 
         return true;
     }
-    
+
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.Die))]
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.OnGameEnd))]
     [HarmonyPatch(typeof(PlayerControl), nameof(PlayerControl.OnGameStart))]


### PR DESCRIPTION
## Summary
- Fix stop emoting prompt showing for all players on idle emotes
- Fix NullReferenceException when stopping a looped idle emote
- Fix emote canvas instantiation freezing player movement by lazy-instantiating on first use via a property getter

## Test plan
- [x] Verify emote wheel opens without freezing player movement
- [x] Verify stopping a looped idle emote does not throw NullReferenceException
- [x] Verify stop emoting prompt only shows for the local player
- [ ] Test on Android to confirm the emote button still works